### PR TITLE
Remove redundant clone

### DIFF
--- a/src/helper.rs
+++ b/src/helper.rs
@@ -17,6 +17,6 @@ impl Bigbluebutton {
             .iter()
             .map(|(key, value)| format!("{}={}", key, value))
             .collect();
-        collection.join("&").to_string()
+        collection.join("&")
     }
 }


### PR DESCRIPTION
The `join()` already returns a String,  no need for the `to_string()` which creates a redundant clone.